### PR TITLE
파이어폭스에서 브라우저를 껐다가 키면 설정이 초기화되는 버그 해결

### DIFF
--- a/dcinside_lite.user.js
+++ b/dcinside_lite.user.js
@@ -116,6 +116,7 @@
 	}
 
 	if(typeof GM_setValue !== 'undefined' && typeof GM_getValue !== 'undefined' && typeof GM_listValues !== 'undefined' && typeof GM_deleteValue !== 'undefined'){
+		if (localStorage) var w3clocalStorage=localStorage;
 		var localStorage=new function(){
 			var t=this;
 			var ke1=GM_listValues();
@@ -150,7 +151,14 @@
 				}
 			}
 		};
-		BROWSER.localStorage=true;
+		if(typeof w3clocalStorage !== "undefined" && w3clocalStorage.getItem("version")!=""){
+			for(var i=0;i<w3clocalStorage.length;i++){
+				var k=w3clocalStorage.key(i);
+				localStorage.setItem(k,w3clocalStorage.getItem(k));
+			}
+			w3clocalStorage.clear();
+		}
+		BROWSER.localStorage = true;
 	}else if (localStorage){
 		BROWSER.localStorage = true; 
 	}else{

--- a/dcinside_lite.user.js
+++ b/dcinside_lite.user.js
@@ -9,6 +9,10 @@
 // @include        http://gall.dcgame.in/*
 // @include        http://job.dcinside.com/*
 // @grant          GM_xmlhttpRequest
+// @grant					 GM_getValue
+// @grant					 GM_setValue
+// @grant					 GM_deleteValue
+// @grant					 GM_listValues
 // ==/UserScript==
 
 (function() {
@@ -111,10 +115,47 @@
 		alert("디시라이트가 지원하지 않는 브라우저입니다.\n\n - 브라우저 타입이 지정되지 않음");
 	}
 
-	if (localStorage)  
+	if(typeof GM_setValue !== 'undefined' && typeof GM_getValue !== 'undefined' && typeof GM_listValues !== 'undefined' && typeof GM_deleteValue !== 'undefined'){
+		var localStorage=new function(){
+			var t=this;
+			var ke1=GM_listValues();
+			ke1.sort();
+			var methods=['setItem','getItem','removeItem','key','clear'];
+			for(var i=0;i<ke1.length;i++){
+				if(methods.indexOf(ke1[i])==-1){
+					t[ke1[i]]=GM_getValue(ke1[i]);
+				}
+			}
+			this.length=ke1.length;
+			this.setItem=function(na,val){
+				GM_setValue(na,val);
+				t[na]=val;
+			}
+			this.getItem=function(na){
+				return GM_getValue(na);
+			}
+			this.removeItem=function(na){
+				GM_deleteValue(na);
+				delete t[na];
+			}
+			this.key=function(index){
+				var names=GM_listValues();
+				names.sort();
+				return names[index];
+			}
+			this.clear=function(){
+				var names=GM_listValues();
+				for(var i=0;i<names;i++){
+					GM_deleteValue(names[i]);
+				}
+			}
+		};
+		BROWSER.localStorage=true;
+	}else if (localStorage){
 		BROWSER.localStorage = true; 
-	else
+	}else{
 		alert("디시라이트가 지원하지 않는 브라우저입니다.\n\n - 로컬 스토리지에 접근할 수 없거나 브라우저가 지원하지 않음");
+	}
 
 	var MODE = {};
 	location.pathnameN = location.pathname.replace(/\/+$/, '');
@@ -288,10 +329,6 @@
 			}
 			P[name] = value;
 			localStorage.setItem(name, value);
-			return;
-		}else if(BROWSER.firefox && type === undefined) {
-			P[name] = value;
-			GM_setValue(name,value);
 			return;
 		}
 


### PR DESCRIPTION
파이어폭스에서 설정을 해도 브라우저를 껐다가 키면 다시 설정 버튼 눌러서 설정하라고 뜨는 버그를 해결했습니다.